### PR TITLE
게시글 단건 조회 api 개선 - 게시글 조회 시 게시글의 댓글까지 조회

### DIFF
--- a/src/main/java/com/gabia/gyebalja/domain/Board.java
+++ b/src/main/java/com/gabia/gyebalja/domain/Board.java
@@ -16,18 +16,22 @@ public class Board {
     private String content;
     private Long views;
     private Long likes;
-    private LocalDate created_date;
-    private LocalDate modified_date;
-    private Long user_id;
-    private Long edu_id;
+    @Column(name = "user_id")
+    private Long userId;
+    @Column(name = "edu_id")
+    private Long eduId;
+    @Column(name = "created_date")
+    private LocalDate createdDate;
+    @Column(name = "modified_date")
+    private LocalDate modifiedDate;
 
     public Board(){
         this.title = "";
         this.content = "";
-        this.created_date = LocalDate.now();
-        this.modified_date = LocalDate.now();
-        this.user_id = 0L;
-        this.edu_id = 0L;
+        this.userId = 0L;
+        this.eduId = 0L;
+        this.createdDate = LocalDate.now();
+        this.modifiedDate = LocalDate.now();
     }
 
     @Builder
@@ -36,10 +40,10 @@ public class Board {
         this.content = content;
         this.views = 0L;
         this.likes = 0L;
-        this.created_date = LocalDate.now();
-        this.modified_date = LocalDate.now();
-        this.user_id = 0L;
-        this.edu_id = 0L;
+        this.userId = 0L;
+        this.eduId = 0L;
+        this.createdDate = LocalDate.now();
+        this.modifiedDate = LocalDate.now();
     }
 
     public void changeTitle(String title) {

--- a/src/main/java/com/gabia/gyebalja/domain/Comment.java
+++ b/src/main/java/com/gabia/gyebalja/domain/Comment.java
@@ -4,10 +4,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
+import javax.persistence.*;
 import java.time.LocalDate;
 
 @ToString
@@ -17,25 +14,29 @@ public class Comment {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String content;
-    private Long board_id;
-    private Long user_id;
-    private LocalDate created_date;
-    private LocalDate modified_date;
+    @Column(name = "board_id")
+    private Long boardId;
+    @Column(name = "user_id")
+    private Long userId;
+    @Column(name = "created_date")
+    private LocalDate createdDate;
+    @Column (name = "modified_date")
+    private LocalDate modifiedDate;
 
     public Comment(){
-        this.board_id = 1L;
-        this.user_id = 1L;
-        this.created_date = LocalDate.now();
-        this.modified_date = LocalDate.now();
+        this.boardId = 1L;
+        this.userId = 1L;
+        this.createdDate = LocalDate.now();
+        this.modifiedDate = LocalDate.now();
     }
 
     @Builder
     public Comment(String content){
         this.content = content;
-        this.board_id = 1L;
-        this.user_id = 1L;
-        this.created_date = LocalDate.now();
-        this.modified_date = LocalDate.now();
+        this.boardId = 1L;
+        this.userId = 1L;
+        this.createdDate = LocalDate.now();
+        this.modifiedDate = LocalDate.now();
     }
 
     public void changeContent(String content){

--- a/src/main/java/com/gabia/gyebalja/dto/BoardDto.java
+++ b/src/main/java/com/gabia/gyebalja/dto/BoardDto.java
@@ -4,6 +4,8 @@ import com.gabia.gyebalja.domain.Board;
 import lombok.*;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
 @NoArgsConstructor
 @ToString
@@ -19,6 +21,7 @@ public class BoardDto {
     private LocalDate modifiedDate;
     private Long userId;
     private Long eduId;
+    private List<CommentDto> commentList;
 
     @Builder
     public BoardDto(String title, String content){
@@ -30,6 +33,7 @@ public class BoardDto {
         this.modifiedDate = LocalDate.now();
         this.userId = 0L;
         this.eduId = 0L;
+        this.commentList = new ArrayList<CommentDto>();
     }
 
     public BoardDto(Board board){
@@ -40,8 +44,13 @@ public class BoardDto {
         this.like = board.getLikes();
         this.createdDate = LocalDate.now();
         this.modifiedDate = LocalDate.now();
-        this.userId = board.getUser_id();
-        this.eduId = board.getEdu_id();
+        this.userId = board.getUserId();
+        this.eduId = board.getEduId();
+        this.commentList = new ArrayList<CommentDto>();
+    }
+
+    public void changeCommentList(List<CommentDto> commentDtoList){
+        this.commentList = commentDtoList;
     }
 
     public Board toEntity(){

--- a/src/main/java/com/gabia/gyebalja/dto/CommentDto.java
+++ b/src/main/java/com/gabia/gyebalja/dto/CommentDto.java
@@ -29,10 +29,10 @@ public class CommentDto {
     public CommentDto(Comment comment){
         this.id = comment.getId();
         this.content = comment.getContent();
-        this.boardId = comment.getBoard_id();
-        this.userId = comment.getUser_id();
-        this.createdDate = comment.getCreated_date();
-        this.modifiedDate = comment.getModified_date();
+        this.boardId = comment.getBoardId();
+        this.userId = comment.getUserId();
+        this.createdDate = comment.getCreatedDate();
+        this.modifiedDate = comment.getModifiedDate();
     }
 
     public Comment toEntity(){

--- a/src/main/java/com/gabia/gyebalja/repository/CommentRepository.java
+++ b/src/main/java/com/gabia/gyebalja/repository/CommentRepository.java
@@ -3,5 +3,8 @@ package com.gabia.gyebalja.repository;
 import com.gabia.gyebalja.domain.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+    List<Comment> findByBoardId(Long id);  // 검토. throws
 }

--- a/src/main/java/com/gabia/gyebalja/service/BoardService.java
+++ b/src/main/java/com/gabia/gyebalja/service/BoardService.java
@@ -1,16 +1,23 @@
 package com.gabia.gyebalja.service;
 
 import com.gabia.gyebalja.domain.Board;
+import com.gabia.gyebalja.domain.Comment;
 import com.gabia.gyebalja.dto.BoardDto;
+import com.gabia.gyebalja.dto.CommentDto;
 import com.gabia.gyebalja.repository.BoardRepository;
+import com.gabia.gyebalja.repository.CommentRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Service
 public class BoardService {
     private final BoardRepository boardRepository;
+    private final CommentRepository commentRepository;
 
     /** 등록 - board 한 건 (게시글 등록) */
     @Transactional
@@ -24,14 +31,22 @@ public class BoardService {
     @Transactional
     public BoardDto findById(Long id){
         Board board = boardRepository.findById(id).orElseThrow(() -> new IllegalArgumentException("해당 게시글이 없습니다."));    // 검토. 404 Error?
+        BoardDto boardDto = new BoardDto(board);
 
-        return new BoardDto(board);
+        // 게시글에 속한 댓글 조회, boardDto 에 삽입
+        List<Comment> commentList = commentRepository.findByBoardId(id);
+        List<CommentDto> commentDtoList = commentList.stream().map(comment -> new CommentDto(comment)).collect(Collectors.toList());
+
+        boardDto.changeCommentList(commentDtoList);
+
+        return boardDto;
     }
 
     /** 수정 - board 한 건 (상세페이지에서) */
     @Transactional
     public Long update(Long id, BoardDto boardDto){
         Board board = boardRepository.findById(id).orElseThrow(() -> new IllegalArgumentException("해당 게시글이 없습니다."));    // 검토. 404 Error?
+
         // 더티 체킹
         board.changeTitle(boardDto.getTitle());
         board.changeContent(boardDto.getContent());

--- a/src/test/java/com/gabia/gyebalja/board/BoardTest.java
+++ b/src/test/java/com/gabia/gyebalja/board/BoardTest.java
@@ -2,7 +2,9 @@ package com.gabia.gyebalja.board;
 
 import com.gabia.gyebalja.domain.Board;
 import com.gabia.gyebalja.dto.BoardDto;
+import com.gabia.gyebalja.dto.CommentDto;
 import com.gabia.gyebalja.repository.BoardRepository;
+import com.gabia.gyebalja.repository.CommentRepository;
 import com.gabia.gyebalja.service.BoardService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,6 +14,8 @@ import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.http.*;
 import org.springframework.test.annotation.Rollback;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Rollback(true)
@@ -19,6 +23,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class BoardTest {
     @Autowired
     BoardRepository boardRepository;
+    @Autowired
+    CommentRepository commentRepository;
     @Autowired
     BoardService boardService;
     @Autowired
@@ -64,6 +70,7 @@ public class BoardTest {
         assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(responseEntity.getBody().getTitle()).isEqualTo(boardDto.getTitle());
         assertThat(responseEntity.getBody().getContent()).isEqualTo(boardDto.getContent());
+        assertThat(responseEntity.getBody().getCommentList().size()).isEqualTo(commentRepository.findByBoardId(targetId).size());    // 게시글의 댓글 테스트 (개수로 테스트)
     }
 
     /** 수정 - board 한 건 (상세페이지에서) */

--- a/src/test/java/com/gabia/gyebalja/comment/CommentTest.java
+++ b/src/test/java/com/gabia/gyebalja/comment/CommentTest.java
@@ -12,6 +12,9 @@ import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.http.*;
 import org.springframework.test.annotation.Rollback;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Rollback(true)
@@ -64,7 +67,7 @@ public class CommentTest {
     }
 
     /** 수정 - comment 한 건
-     *  새 데이터 삽입 후 내용 변경하여 진행
+     *  새 데이터 삽입 후 내용 변경하여 수정 잘 되었는지 테스트 진행
      * */
     @Test
     public void putOneComment(){
@@ -88,7 +91,7 @@ public class CommentTest {
     }
 
     /** 삭제 - comment 한 건
-     *  데이터 개수로 테스트 진행 (삽입 전 개수 - 삽입 후, 삭제 후 개수 동일 체크)
+     *  데이터 개수로 테스트 진행 (삽입 전 개수와 삽입, 삭제 후 개수 동일 체크)
      * */
     @Test
     public void deleteOneComment(){
@@ -108,5 +111,23 @@ public class CommentTest {
         assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(responseEntity.getBody()).isGreaterThan(0L);
         assertThat(commentRepository.count()).isEqualTo(totalCount);
+    }
+
+    /** 쿼리메소드 테스트 findByBoardId() */
+    @Test
+    public void findByBoardIdTest(){
+        // given
+        Long targetId = 1L;
+        List<Comment> commentList = new ArrayList<Comment>();
+
+        // when
+        try {
+            commentList = commentRepository.findByBoardId(targetId);
+        }catch (Exception e) {
+            System.out.println(e);
+        }
+
+        // then
+        System.out.println(commentList.toString());
     }
 }


### PR DESCRIPTION
**게시글 단건 조회 api 개선 - 게시글 조회 시 게시글의 댓글까지 조회**

- 게시글 조회 시 게시글에 포함된 댓글까지 조회하는 기능 구현

- 테스트 코드 작성 (통과)

- Entity 클래스 컬럼명 변경 (언더바 제거) --> 쿼리메소드 사용 위함