### PR TITLE
#24 테스트 코드 작성 - BoardRepository  -  jpaRepository.save() 수정

### DIFF
--- a/src/test/java/com/gabia/gyebalja/board/BoardRepositoryTest.java
+++ b/src/test/java/com/gabia/gyebalja/board/BoardRepositoryTest.java
@@ -5,7 +5,6 @@ import com.gabia.gyebalja.repository.*;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.Rollback;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.EntityManager;
@@ -48,7 +47,6 @@ public class BoardRepositoryTest {
                 .depth(0)
                 .parentDepartment(null)
                 .build();
-        departmentRepository.save(this.department);
 
         // User
         this.user = User.builder()
@@ -63,13 +61,11 @@ public class BoardRepositoryTest {
                 .department(this.department)
                 .profileImg(null)
                 .build();
-        userRepository.save(this.user);
 
         // Category
         this.category = Category.builder()
                 .name("개발")
                 .build();
-        categoryRepository.save(this.category);
 
         // Education
         this.education = Education.builder()
@@ -83,7 +79,6 @@ public class BoardRepositoryTest {
                 .user(this.user)
                 .category(this.category)
                 .build();
-        educationRepository.save(this.education);
 
         // Board
         this.board = Board.builder().title("테스트 - 게시글 제목").content("테스트 - 게시글 본문").views(0).user(this.user).education(this.education).build();
@@ -93,6 +88,11 @@ public class BoardRepositoryTest {
     @Test
     public void saveTest() {
         // given
+        departmentRepository.save(this.department);
+        userRepository.save(this.user);
+        categoryRepository.save(this.category);
+        educationRepository.save(this.education);
+
         Long totalNumberOfData = boardRepository.count();
         Board board = this.board;
 
@@ -113,6 +113,11 @@ public class BoardRepositoryTest {
     @Test
     public void findTest() {
         // given
+        departmentRepository.save(this.department);
+        userRepository.save(this.user);
+        categoryRepository.save(this.category);
+        educationRepository.save(this.education);
+
         Board board = this.board;
         Board saveBoard = boardRepository.save(board);
         em.flush();
@@ -133,6 +138,11 @@ public class BoardRepositoryTest {
     @Test
     public void updateTest() {
         // given
+        departmentRepository.save(this.department);
+        userRepository.save(this.user);
+        categoryRepository.save(this.category);
+        educationRepository.save(this.education);
+
         String updateTitle = "테스트 - 게시글 제목 업데이트";
         String updateContent = "테스트 - 게시글 본문 업데이트";
         Board board = this.board;
@@ -155,6 +165,11 @@ public class BoardRepositoryTest {
     @Test
     public void deleteTest() {
         // given
+        departmentRepository.save(this.department);
+        userRepository.save(this.user);
+        categoryRepository.save(this.category);
+        educationRepository.save(this.education);
+
         Long totalNumberOfData = boardRepository.count();
         Board board = this.board;
         Board saveBoard = boardRepository.save(board);

--- a/src/test/java/com/gabia/gyebalja/comment/CommentRepositoryTest.java
+++ b/src/test/java/com/gabia/gyebalja/comment/CommentRepositoryTest.java
@@ -1,0 +1,173 @@
+package com.gabia.gyebalja.comment;
+
+import com.gabia.gyebalja.domain.*;
+import com.gabia.gyebalja.repository.*;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Transactional
+@SpringBootTest
+public class CommentRepositoryTest {
+    @PersistenceContext
+    EntityManager em;
+
+    private final CommentRepository commentRepository;
+    private final BoardRepository boardRepository;
+    private final UserRepository userRepository;
+    private final DepartmentRepository departmentRepository;
+    private final CategoryRepository categoryRepository;
+    private final EducationRepository educationRepository;
+
+    private Comment comment;
+    private Board board;
+    private User user;
+    private Department department;
+    private Category category;
+    private Education education;
+
+    @Autowired
+    public CommentRepositoryTest(CommentRepository commentRepository, BoardRepository boardRepository, UserRepository userRepository, DepartmentRepository departmentRepository,
+                                 CategoryRepository categoryRepository, EducationRepository educationRepository) {
+        this.commentRepository = commentRepository;
+        this.boardRepository = boardRepository;
+        this.userRepository = userRepository;
+        this.departmentRepository = departmentRepository;
+        this.categoryRepository = categoryRepository;
+        this.educationRepository = educationRepository;
+
+        // Department
+        this.department = Department.builder()
+                .name("테스트팀")
+                .depth(0)
+                .parentDepartment(null)
+                .build();
+        departmentRepository.save(this.department);
+
+        // User
+        this.user = User.builder()
+                .email("gabiaUser@gabia.com")
+                .password("1234")
+                .name("가비아")
+                .gender(UserGender.MALE)
+                .phone("010-2345-5678")
+                .tel("02-2345-5678")
+                .positionId(5L)
+                .positionName("직원")
+                .department(this.department)
+                .profileImg(null)
+                .build();
+        userRepository.save(this.user);
+
+        // Category
+        this.category = Category.builder()
+                .name("개발")
+                .build();
+        categoryRepository.save(this.category);
+
+        // Education
+        this.education = Education.builder()
+                .title("테스트 - Mysql 초급 강좌 제목")
+                .content("테스트 - Mysql 초급 강좌 본문")
+                .startDate(LocalDate.now())
+                .endDate(LocalDate.now())
+                .totalHours(10)
+                .type(EducationType.ONLINE)
+                .place("테스트 - 인프런 온라인 교육 사이트")
+                .user(this.user)
+                .category(this.category)
+                .build();
+        educationRepository.save(this.education);
+
+        // Board
+        this.board = Board.builder().title("테스트 - 게시글 제목").content("테스트 - 게시글 본문").views(0).user(this.user).education(this.education).build();
+        boardRepository.save(this.board);
+        // Comment
+        this.comment = comment.builder().content("테스트 - 댓글 본문").board(this.board).user(this.user).build();
+    }
+
+
+    /** Create Test */
+    @Test
+    public void saveTest(){
+        // given
+        Long totalNumberOfData = commentRepository.count();
+        Comment comment = this.comment;
+        em.flush();
+        em.clear();
+
+        // when
+        Comment saveComment = commentRepository.save(comment);
+
+        // then
+        Comment findComment = commentRepository.findById(saveComment.getId()).orElseThrow(() -> new IllegalArgumentException("해당 데이터가 없습니다."));
+        assertThat(commentRepository.count()).isEqualTo(totalNumberOfData + 1);
+        assertThat(findComment.getId()).isEqualTo(saveComment.getId());
+        assertThat(findComment.getContent()).isEqualTo(saveComment.getContent());
+        assertThat(findComment.getBoard().getId()).isEqualTo(saveComment.getBoard().getId());
+    }
+
+    /** Retrieve Test */
+    @Test
+    public void findComment(){
+        // given
+        Comment comment = this.comment;
+        Comment saveComment = commentRepository.save(comment);
+        em.flush();
+        em.clear();
+
+        // when
+        Comment findComment = commentRepository.findById(saveComment.getId()).orElseThrow(()->new IllegalArgumentException("해당 데이터가 없습니다."));
+
+        // then
+        assertThat(findComment.getId()).isEqualTo(saveComment.getId());
+        assertThat(findComment.getContent()).isEqualTo(saveComment.getContent());
+        assertThat(findComment.getBoard().getId()).isEqualTo(saveComment.getBoard().getId());
+        assertThat(findComment.getUser().getId()).isEqualTo(saveComment.getUser().getId());
+    }
+
+    /** Update Test */
+    @Test
+    public void updateComment(){
+        // given
+        String updateContent = "테스트 - 댓글 본문 업데이트";
+        Comment comment = this.comment;
+        Comment saveComment = commentRepository.save(comment);
+        Comment findComment = commentRepository.findById(saveComment.getId()).orElseThrow(() -> new IllegalArgumentException("해당 데이터가 없습니다."));
+        findComment.changeContent(updateContent);
+        em.flush();
+        em.clear();
+
+        // when
+        Comment updateComment = commentRepository.save(findComment);
+
+        // then
+        assertThat(updateComment.getContent()).isEqualTo(findComment.getContent());
+    }
+
+    /** Delete Test */
+    @Test
+    public void deleteComment(){
+        // given
+        Long totlaNumberOfData = commentRepository.count();
+        Comment comment = this.comment;
+        Comment saveComment = commentRepository.save(comment);
+        em.flush();
+        em.clear();
+
+        // when
+        commentRepository.deleteById(saveComment.getId());
+
+        // then
+        assertThat(commentRepository.count()).isEqualTo(totlaNumberOfData);
+        assertThat(commentRepository.findById(saveComment.getId())).isEqualTo(Optional.empty());
+    }
+}


### PR DESCRIPTION
#24 테스트 코드 작성 - BoardRepository  -  jpaRepository.save() 수정

- 수정 - 레포지토리 save 각 메소드 안에서 작성 (생성자의 경우 트랜잭션 안먹히는 현상)

- 생성자 내의 연관객체들의 jpaRepository.save()를 각 테스트 메소드 내에서 작성했습니다.