### PR TITLE
#54 테스트 코드 작성 - CategoryRepository, TagRepository, EduTagRepository 

### DIFF
--- a/src/main/java/com/gabia/gyebalja/domain/Category.java
+++ b/src/main/java/com/gabia/gyebalja/domain/Category.java
@@ -5,16 +5,19 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.persistence.*;
-import java.util.ArrayList;
-import java.util.List;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 public class Category extends BaseTime {
 
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Column(nullable = false)
@@ -25,4 +28,7 @@ public class Category extends BaseTime {
         this.name = name;
     }
 
+    public void changeCategoryName(String name) {
+        this.name = name;
+    }
 }

--- a/src/main/java/com/gabia/gyebalja/domain/EduTag.java
+++ b/src/main/java/com/gabia/gyebalja/domain/EduTag.java
@@ -4,8 +4,15 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import javax.persistence.*;
 
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -13,7 +20,8 @@ import javax.persistence.*;
 @Table(name = "edu_tag")
 public class EduTag extends BaseTime {
 
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     //Education과 연관관계
@@ -29,6 +37,13 @@ public class EduTag extends BaseTime {
     @Builder
     public EduTag(Education education, Tag tag) {
         this.education = education;
+        this.tag = tag;
+    }
+
+    public void changeEducation(Education education) {
+        this.education = education;
+    }
+    public void changeTag(Tag tag) {
         this.tag = tag;
     }
 }

--- a/src/main/java/com/gabia/gyebalja/domain/Education.java
+++ b/src/main/java/com/gabia/gyebalja/domain/Education.java
@@ -1,12 +1,21 @@
 package com.gabia.gyebalja.domain;
 
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
-import javax.persistence.*;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
-
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED) //프록시가 이생성자를 사용함 다른생성자를 사용하려면 기본생성자가 필요한데 Protected로 기본생성자를 만들어줌.
@@ -14,7 +23,8 @@ import java.util.List;
 public class Education extends BaseTime {
 
     //교육 테이블 id (PK)
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY) //기본키 생성을 DB에 위임
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY) //기본키 생성을 DB에 위임
     private Long id;
 
     //교육 테이블 제목
@@ -37,15 +47,11 @@ public class Education extends BaseTime {
 
     //교육 유형 (ONLINE, OFFLINE)
     @Enumerated(EnumType.STRING) //ORIGINAL로 하면 유지보수성이 떨어짐으로 STRING으로 사용
+    @Column(nullable = false)
     private EducationType type;
 
     //교육 장소
     private String place;
-
-
-    //생성일, 수정일
-//    private LocalDateTime createdDate;
-//    private LocalDateTime modifiedDate;
 
     //User와 연관관계
     @ManyToOne(fetch = FetchType.LAZY)
@@ -78,30 +84,6 @@ public class Education extends BaseTime {
     public void changeContent(String content) {
         this.content = content;
     }
-
-
-//    @Builder
-//    public Education(String title, String content, LocalDate startDate, LocalDate endDate, int totalHours, EducationType type, String place) {
-//        this.title = title;
-//        this.content = content;
-//        this.startDate = startDate;
-//        this.endDate = endDate;
-//        this.totalHours = totalHours;
-//        this.type = type;
-//        this.place = place;
-//    }
-
-//
-//    //교육내용 변경 메서드
-//    public void changeEducation(String title, String content, LocalDateTime startDate, LocalDateTime endDate, int totalHours, EducationType type, String place ) {
-//        this.title = title;
-//        this.content = content;
-//        this.startDate = startDate;
-//        this.endDate = endDate;
-//        this.totalHours = totalHours;
-//        this.type = type;
-//        this.place = place;
-//    }
 
 
 }

--- a/src/main/java/com/gabia/gyebalja/domain/Tag.java
+++ b/src/main/java/com/gabia/gyebalja/domain/Tag.java
@@ -4,16 +4,20 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import javax.persistence.*;
-import java.util.ArrayList;
-import java.util.List;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 public class Tag extends BaseTime {
 
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Column(nullable = false)
@@ -21,6 +25,10 @@ public class Tag extends BaseTime {
 
     @Builder
     public Tag(String name) {
+        this.name = name;
+    }
+
+    public void changeTagName(String name) {
         this.name = name;
     }
 

--- a/src/main/java/com/gabia/gyebalja/domain/User.java
+++ b/src/main/java/com/gabia/gyebalja/domain/User.java
@@ -1,20 +1,28 @@
 package com.gabia.gyebalja.domain;
 
-
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import javax.persistence.*;
-import java.util.ArrayList;
-import java.util.List;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 public class User extends BaseTime {
 
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY) //기본키 생성 전략중 데이터베이스 위임 'IDENTITY' 사용 (mysql)
     private Long id;
 
     @Column(nullable = false)
@@ -25,6 +33,10 @@ public class User extends BaseTime {
     @Column(length = 15, nullable = false)
     private String name;
 
+    /**
+     * enum 사용 시 Default가 ORDINARY인데 이것을 사용시 확장성에서도 문제가 생기며 유연하지 않음
+     * 꼭 EnumType.STRING 사용!
+     */
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private GenderType gender;
@@ -60,21 +72,9 @@ public class User extends BaseTime {
         this.department = department;
     }
 
-
-    /**
-     * 연관관계 메서드 세팅
-     * 유저의 부서가 변경된 경우
-     */
-//    public void changeDept(Department department) {
-//        this.department = department;
-//
-//        department.getUsers().add(this);
-//    }
-
+    //비밀번호 변경 비즈니스 로직
     public void changePassword(String password) {
         this.password = password;
     }
-
-
 
 }

--- a/src/test/java/com/gabia/gyebalja/category/CatecoryRepositoryTest.java
+++ b/src/test/java/com/gabia/gyebalja/category/CatecoryRepositoryTest.java
@@ -1,0 +1,168 @@
+package com.gabia.gyebalja.category;
+
+import com.gabia.gyebalja.domain.Category;
+import com.gabia.gyebalja.repository.CategoryRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+
+@Transactional
+@SpringBootTest
+public class CatecoryRepositoryTest {
+
+    @PersistenceContext
+    EntityManager em;
+
+    @Autowired
+    CategoryRepository categoryRepository;
+
+    @Test
+    @DisplayName("Category 저장 테스트(save)")
+    public void saveTest() throws Exception {
+        //given
+        Long beforeCnt = categoryRepository.count();
+
+        Category category = Category.builder()
+                .name("개발자")
+                .build();
+
+        //when
+        categoryRepository.save(category);
+        em.clear();  //영속성 컨텍스트 초기화 ( 1차캐시에서 조회하는것을 막기위해)
+
+        Category findCategory = categoryRepository.findById(category.getId()).get();
+
+        //then
+        assertThat(findCategory.getId()).isEqualTo(category.getId());
+        assertThat(findCategory.getName()).isEqualTo(category.getName());
+        assertThat(categoryRepository.count()).isEqualTo(beforeCnt+1);
+
+    }
+
+    @Test
+    @DisplayName("Category 단건조회 테스트(findById)")
+    public void findByIdTest() throws Exception {
+        //given
+        Category category1 = Category.builder()
+                .name("개발자")
+                .build();
+        categoryRepository.save(category1);
+
+        Category category2 = Category.builder()
+                .name("기획자")
+                .build();
+        categoryRepository.save(category2);
+
+        em.clear();
+        //when
+        Category findCategory = categoryRepository.findById(category2.getId()).get();
+
+        //then
+        assertThat(findCategory.getId()).isEqualTo(category2.getId());
+        assertThat(findCategory.getName()).isEqualTo(category2.getName());
+    }
+
+    @Test
+    @DisplayName("Category 전체 조회 테스트(findAll)")
+    public void findAllTest() throws Exception {
+        //given
+        Category category1 = Category.builder()
+                .name("개발자")
+                .build();
+        categoryRepository.save(category1);
+
+        Category category2 = Category.builder()
+                .name("기획자")
+                .build();
+        categoryRepository.save(category2);
+
+        em.clear();
+        //when
+        List<Category> allCategory = categoryRepository.findAll();
+
+        //then
+        assertThat(allCategory.size()).isEqualTo(2);
+        assertThat(allCategory.get(0).getId()).isEqualTo(category1.getId());
+        assertThat(allCategory.get(0).getName()).isEqualTo(category1.getName());
+    }
+
+    @Test
+    @DisplayName("Category 갯수 테스트(count)")
+    public void countTest() throws Exception {
+        //given
+        Category category1 = Category.builder()
+                .name("개발자")
+                .build();
+        categoryRepository.save(category1);
+
+        Category category2 = Category.builder()
+                .name("기획자")
+                .build();
+        categoryRepository.save(category2);
+        //when
+        long count = categoryRepository.count();
+        //then
+        assertThat(count).isEqualTo(2);
+
+    }
+
+    @Test
+    @DisplayName("Category 삭제 테스트(delete")
+    public void deleteTest() throws Exception {
+        //given
+        Category category1 = Category.builder()
+                .name("개발자")
+                .build();
+        categoryRepository.save(category1);
+
+        Category category2 = Category.builder()
+                .name("기획자")
+                .build();
+        categoryRepository.save(category2);
+
+        long beforeDeleteCnt = categoryRepository.count();
+        //when
+        categoryRepository.delete(category1);
+        //then
+        assertThat(categoryRepository.count()).isEqualTo(beforeDeleteCnt-1);
+        assertThat(categoryRepository.findById(category1.getId())).isEqualTo(Optional.empty());
+
+    }
+
+    @Test
+    @DisplayName("Category 업데이트 테스트(update)")
+    public void updateTest() throws Exception {
+        //given
+        String updateName = "이름 업데이트";
+        
+        Category category = Category.builder()
+                                    .name("개발자")
+                                    .build();
+        categoryRepository.save(category);
+        long beforeUpdateCnt = categoryRepository.count();
+        //when
+        category.changeCategoryName(updateName);
+        em.flush();
+        Category findCategory = categoryRepository.findById(category.getId()).get();
+        
+        //then
+        assertThat(findCategory.getId()).isEqualTo(category.getId());
+        assertThat(findCategory.getName()).isEqualTo(updateName);
+        assertThat(categoryRepository.count()).isEqualTo(beforeUpdateCnt);
+
+        
+    }
+        
+
+
+}

--- a/src/test/java/com/gabia/gyebalja/edutag/EduTagRepositoryTest.java
+++ b/src/test/java/com/gabia/gyebalja/edutag/EduTagRepositoryTest.java
@@ -1,0 +1,437 @@
+package com.gabia.gyebalja.edutag;
+
+import com.gabia.gyebalja.domain.*;
+import com.gabia.gyebalja.repository.*;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+
+@Transactional
+@SpringBootTest
+public class EduTagRepositoryTest {
+
+    @PersistenceContext
+    EntityManager em;
+
+    @Autowired
+    EduTagRepository eduTagRepository;
+    @Autowired
+    TagRepository tagRepository;
+    @Autowired
+    EducationRepository educationRepository;
+    @Autowired
+    UserRepository userRepository;
+    @Autowired
+    CategoryRepository categoryRepository;
+    @Autowired
+    DepartmentRepository departmentRepository;
+
+    @Test
+    @DisplayName("EduTag 저장 테스트(save)")
+    public void saveTest() throws Exception {
+        //given
+        long beforeCnt = eduTagRepository.count();
+
+        Category category = Category.builder()
+                .name("개발자")
+                .build();
+        categoryRepository.save(category);
+
+        Department department = Department.builder()
+                .name("테스트팀")
+                .depth(2)
+                .parentDepartment(null)
+                .build();
+        departmentRepository.save(department);
+
+        User user = User.builder()
+                .email("test@gabia.com")
+                .password("1234")
+                .name("User1")
+                .gender(GenderType.MALE)
+                .phone("000-000-0000")
+                .tel("111-111-1111")
+                .positionId(123L)
+                .positionName("팀원")
+                .department(department)
+                .profileImg("src/img")
+                .build();
+        userRepository.save(user);
+
+        Education education = Education.builder()
+                .title("제목테스트")
+                .content("내용테스트")
+                .startDate(LocalDate.now())
+                .endDate(LocalDate.now())
+                .totalHours(3)
+                .type(EducationType.ONLINE)
+                .place("가비아 4층")
+                .category(category)
+                .user(user)
+                .build();
+        educationRepository.save(education);
+
+        Tag tag = Tag.builder()
+                .name("Spring")
+                .build();
+        tagRepository.save(tag);
+
+        EduTag eduTag = EduTag.builder()
+                            .tag(tag)
+                            .education(education)
+                            .build();
+
+        //when
+        eduTagRepository.save(eduTag);
+        em.clear();
+
+        EduTag findEduTag = eduTagRepository.findById(eduTag.getId()).get();
+        //then
+        assertThat(findEduTag.getId()).isEqualTo(eduTag.getId());
+        assertThat(findEduTag.getEducation().getId()).isEqualTo(eduTag.getEducation().getId());
+        assertThat(findEduTag.getTag().getId()).isEqualTo(eduTag.getTag().getId());
+        assertThat(eduTagRepository.count()).isEqualTo(beforeCnt+1);
+    }
+
+    @Test
+    @DisplayName("EduTag 단건조회 테스트(findById)")
+    public void findByIdTest() throws Exception {
+        //given
+        Category category = Category.builder()
+                .name("개발자")
+                .build();
+        categoryRepository.save(category);
+
+        Department department = Department.builder()
+                .name("테스트팀")
+                .depth(2)
+                .parentDepartment(null)
+                .build();
+        departmentRepository.save(department);
+
+        User user = User.builder()
+                .email("test@gabia.com")
+                .password("1234")
+                .name("User1")
+                .gender(GenderType.MALE)
+                .phone("000-000-0000")
+                .tel("111-111-1111")
+                .positionId(123L)
+                .positionName("팀원")
+                .department(department)
+                .profileImg("src/img")
+                .build();
+        userRepository.save(user);
+
+        Education education = Education.builder()
+                .title("제목테스트")
+                .content("내용테스트")
+                .startDate(LocalDate.now())
+                .endDate(LocalDate.now())
+                .totalHours(3)
+                .type(EducationType.ONLINE)
+                .place("가비아 4층")
+                .category(category)
+                .user(user)
+                .build();
+        educationRepository.save(education);
+
+        Tag tag = Tag.builder()
+                .name("Spring")
+                .build();
+        tagRepository.save(tag);
+
+        EduTag eduTag = EduTag.builder()
+                .tag(tag)
+                .education(education)
+                .build();
+        eduTagRepository.save(eduTag);
+
+        em.clear();
+        //when
+        EduTag findEduTag = eduTagRepository.findById(eduTag.getId()).get();
+        //then
+        assertThat(findEduTag.getId()).isEqualTo(eduTag.getId());
+        assertThat(findEduTag.getTag().getId()).isEqualTo(eduTag.getTag().getId());
+        assertThat(findEduTag.getEducation().getId()).isEqualTo(eduTag.getEducation().getId());
+    }
+
+    @Test
+    @DisplayName("EduTag 전체 조회 테스트(findAll)")
+    public void findAllTest() throws Exception {
+        //given
+        Category category = Category.builder()
+                .name("개발자")
+                .build();
+        categoryRepository.save(category);
+
+        Department department = Department.builder()
+                .name("테스트팀")
+                .depth(2)
+                .parentDepartment(null)
+                .build();
+        departmentRepository.save(department);
+
+        User user = User.builder()
+                .email("test@gabia.com")
+                .password("1234")
+                .name("User1")
+                .gender(GenderType.MALE)
+                .phone("000-000-0000")
+                .tel("111-111-1111")
+                .positionId(123L)
+                .positionName("팀원")
+                .department(department)
+                .profileImg("src/img")
+                .build();
+        userRepository.save(user);
+
+        Education education = Education.builder()
+                .title("제목테스트")
+                .content("내용테스트")
+                .startDate(LocalDate.now())
+                .endDate(LocalDate.now())
+                .totalHours(3)
+                .type(EducationType.ONLINE)
+                .place("가비아 4층")
+                .category(category)
+                .user(user)
+                .build();
+        educationRepository.save(education);
+
+        Tag tag = Tag.builder()
+                .name("Spring")
+                .build();
+        tagRepository.save(tag);
+
+        EduTag eduTag = EduTag.builder()
+                .tag(tag)
+                .education(education)
+                .build();
+        eduTagRepository.save(eduTag);
+
+        em.clear();
+        //when
+        List<EduTag> allEduTag = eduTagRepository.findAll();
+        //then
+        assertThat(allEduTag.size()).isEqualTo(1);
+        assertThat(allEduTag.get(0).getId()).isEqualTo(eduTag.getId());
+        assertThat(allEduTag.get(0).getTag().getId()).isEqualTo(eduTag.getTag().getId());
+        assertThat(allEduTag.get(0).getEducation().getId()).isEqualTo(eduTag.getEducation().getId());
+    }
+
+    @Test
+    @DisplayName("EduTag 갯수 테스트(count)")
+    public void countTest() throws Exception {
+        //given
+        Category category = Category.builder()
+                .name("개발자")
+                .build();
+        categoryRepository.save(category);
+
+        Department department = Department.builder()
+                .name("테스트팀")
+                .depth(2)
+                .parentDepartment(null)
+                .build();
+        departmentRepository.save(department);
+
+        User user = User.builder()
+                .email("test@gabia.com")
+                .password("1234")
+                .name("User1")
+                .gender(GenderType.MALE)
+                .phone("000-000-0000")
+                .tel("111-111-1111")
+                .positionId(123L)
+                .positionName("팀원")
+                .department(department)
+                .profileImg("src/img")
+                .build();
+        userRepository.save(user);
+
+        Education education = Education.builder()
+                .title("제목테스트")
+                .content("내용테스트")
+                .startDate(LocalDate.now())
+                .endDate(LocalDate.now())
+                .totalHours(3)
+                .type(EducationType.ONLINE)
+                .place("가비아 4층")
+                .category(category)
+                .user(user)
+                .build();
+        educationRepository.save(education);
+
+        Tag tag = Tag.builder()
+                .name("Spring")
+                .build();
+        tagRepository.save(tag);
+
+        EduTag eduTag = EduTag.builder()
+                .tag(tag)
+                .education(education)
+                .build();
+        eduTagRepository.save(eduTag);
+        //when
+        long count = eduTagRepository.count();
+        //then
+        assertThat(count).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("EduTag 삭제 테스트(delete)")
+    public void deleteTest() throws Exception {
+        //given
+        Category category = Category.builder()
+                .name("개발자")
+                .build();
+        categoryRepository.save(category);
+
+        Department department = Department.builder()
+                .name("테스트팀")
+                .depth(2)
+                .parentDepartment(null)
+                .build();
+        departmentRepository.save(department);
+
+        User user = User.builder()
+                .email("test@gabia.com")
+                .password("1234")
+                .name("User1")
+                .gender(GenderType.MALE)
+                .phone("000-000-0000")
+                .tel("111-111-1111")
+                .positionId(123L)
+                .positionName("팀원")
+                .department(department)
+                .profileImg("src/img")
+                .build();
+        userRepository.save(user);
+
+        Education education = Education.builder()
+                .title("제목테스트")
+                .content("내용테스트")
+                .startDate(LocalDate.now())
+                .endDate(LocalDate.now())
+                .totalHours(3)
+                .type(EducationType.ONLINE)
+                .place("가비아 4층")
+                .category(category)
+                .user(user)
+                .build();
+        educationRepository.save(education);
+
+        Tag tag = Tag.builder()
+                .name("Spring")
+                .build();
+        tagRepository.save(tag);
+
+        EduTag eduTag = EduTag.builder()
+                .tag(tag)
+                .education(education)
+                .build();
+        eduTagRepository.save(eduTag);
+
+        long beforeDeleteCnt = eduTagRepository.count();
+        //when
+        eduTagRepository.delete(eduTag);
+        //then
+        assertThat(eduTagRepository.count()).isEqualTo(beforeDeleteCnt-1);
+        assertThat(eduTagRepository.findById(eduTag.getId())).isEqualTo(Optional.empty());
+    }
+
+    @Test
+    @DisplayName("EduTag 업데이트 테스트(update)")
+    public void updateTest() throws Exception {
+        //given
+        Category category = Category.builder()
+                .name("개발자")
+                .build();
+        categoryRepository.save(category);
+
+        Department department = Department.builder()
+                .name("테스트팀")
+                .depth(2)
+                .parentDepartment(null)
+                .build();
+        departmentRepository.save(department);
+
+        User user = User.builder()
+                .email("test@gabia.com")
+                .password("1234")
+                .name("User1")
+                .gender(GenderType.MALE)
+                .phone("000-000-0000")
+                .tel("111-111-1111")
+                .positionId(123L)
+                .positionName("팀원")
+                .department(department)
+                .profileImg("src/img")
+                .build();
+        userRepository.save(user);
+
+        Education education = Education.builder()
+                .title("제목테스트")
+                .content("내용테스트")
+                .startDate(LocalDate.now())
+                .endDate(LocalDate.now())
+                .totalHours(3)
+                .type(EducationType.ONLINE)
+                .place("가비아 4층")
+                .category(category)
+                .user(user)
+                .build();
+        educationRepository.save(education);
+
+        Tag tag = Tag.builder()
+                .name("Spring")
+                .build();
+        tagRepository.save(tag);
+
+        EduTag eduTag = EduTag.builder()
+                .tag(tag)
+                .education(education)
+                .build();
+        eduTagRepository.save(eduTag);
+
+        Education updateEducation = Education.builder()
+                .title("제목업데이트테스트")
+                .content("내용업데이트테스트")
+                .startDate(LocalDate.now())
+                .endDate(LocalDate.now())
+                .totalHours(3)
+                .type(EducationType.ONLINE)
+                .place("가비아 5층")
+                .category(category)
+                .user(user)
+                .build();
+        educationRepository.save(updateEducation);
+
+        long beforeUpdateCnt = eduTagRepository.count();
+        //when
+        eduTag.changeEducation(updateEducation);
+
+        EduTag findEduTag = eduTagRepository.findById(eduTag.getId()).get();
+        //then
+        assertThat(findEduTag.getId()).isEqualTo(eduTag.getId());
+        assertThat(findEduTag.getId()).isEqualTo(eduTag.getId());
+        assertThat(findEduTag.getEducation().getTitle()).isEqualTo(updateEducation.getTitle());
+        assertThat(eduTagRepository.count()).isEqualTo(beforeUpdateCnt);
+    }
+
+}
+/**
+ * given의 반복되는 값 세팅부분 클래스로 만들거나 @Before 사용하기.
+ **/

--- a/src/test/java/com/gabia/gyebalja/tag/TagRepositoryTest.java
+++ b/src/test/java/com/gabia/gyebalja/tag/TagRepositoryTest.java
@@ -1,0 +1,168 @@
+package com.gabia.gyebalja.tag;
+
+import com.gabia.gyebalja.domain.Tag;
+import com.gabia.gyebalja.repository.TagRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+
+@Transactional
+@SpringBootTest
+public class TagRepositoryTest {
+
+    @PersistenceContext
+    EntityManager em;
+
+    @Autowired
+    TagRepository tagRepository;
+
+    @Test
+    @DisplayName("Tag 저장 테스트(save)")
+    public void saveTest() throws Exception {
+        //given
+        long beforeCnt = tagRepository.count();
+
+        Tag tag = Tag.builder()
+                    .name("Spring")
+                    .build();
+
+        //when
+        tagRepository.save(tag);
+        em.clear();
+
+        Tag findTag = tagRepository.findById(tag.getId()).get();
+        //then
+        assertThat(findTag.getId()).isEqualTo(tag.getId());
+        assertThat(findTag.getName()).isEqualTo(tag.getName());
+        assertThat(tagRepository.count()).isEqualTo(beforeCnt+1);
+    }
+
+    @Test
+    @DisplayName("Tag 단건조회 테스트(findById)")
+    public void findByIdTest() throws Exception {
+        //given
+        Tag tag1 = Tag.builder()
+                .name("Spring")
+                .build();
+        tagRepository.save(tag1);
+
+        Tag tag2 = Tag.builder()
+                .name("JPA")
+                .build();
+        tagRepository.save(tag2);
+
+        em.clear();
+        //when
+        Tag findTag = tagRepository.findById(tag2.getId()).get();
+
+        //then
+        assertThat(findTag.getId()).isEqualTo(tag2.getId());
+        assertThat(findTag.getName()).isEqualTo(tag2.getName());
+    }
+
+    @Test
+    @DisplayName("Tag 전체 조회 테스트(findAll)")
+    public void findAllTest() throws Exception {
+        //given
+        Tag tag1 = Tag.builder()
+                .name("Spring")
+                .build();
+        tagRepository.save(tag1);
+
+        Tag tag2 = Tag.builder()
+                .name("JPA")
+                .build();
+        tagRepository.save(tag2);
+
+        em.clear();
+        //when
+        List<Tag> allTag = tagRepository.findAll();
+
+        //then
+        assertThat(allTag.size()).isEqualTo(2);
+        assertThat(allTag.get(0).getId()).isEqualTo(tag1.getId());
+        assertThat(allTag.get(0).getName()).isEqualTo(tag1.getName());
+    }
+
+    @Test
+    @DisplayName("Tag 갯수 테스트(count)")
+    public void countTest() throws Exception {
+        //given
+        Tag tag1 = Tag.builder()
+                .name("Spring")
+                .build();
+        tagRepository.save(tag1);
+
+        Tag tag2 = Tag.builder()
+                .name("JPA")
+                .build();
+        tagRepository.save(tag2);
+        //when
+        long count = tagRepository.count();
+        //then
+        assertThat(count).isEqualTo(2);
+
+    }
+
+    @Test
+    @DisplayName("Tag 삭제 테스트(delete)")
+    public void deleteTest() throws Exception {
+        //given
+        Tag tag1 = Tag.builder()
+                .name("Spring")
+                .build();
+        tagRepository.save(tag1);
+
+        Tag tag2 = Tag.builder()
+                .name("JPA")
+                .build();
+        tagRepository.save(tag2);
+
+        long beforeDeleteCnt = tagRepository.count();
+        //when
+        tagRepository.delete(tag1);
+        //then
+        assertThat(tagRepository.count()).isEqualTo(beforeDeleteCnt-1);
+        assertThat(tagRepository.findById(tag1.getId())).isEqualTo(Optional.empty());
+
+    }
+
+    @Test
+    @DisplayName("Tag 업데이트 테스트(update)")
+    public void updateTest() throws Exception {
+        //given
+        String updateName = "이름 업데이트";
+
+        Tag tag = Tag.builder()
+                    .name("Spring")
+                    .build();
+        tagRepository.save(tag);
+        long beforeUpdateCnt = tagRepository.count();
+        //when
+        tag.changeTagName(updateName);
+        Tag findTag = tagRepository.findById(tag.getId()).get();
+
+        //then
+        assertThat(findTag.getId()).isEqualTo(tag.getId());
+        assertThat(findTag.getName()).isEqualTo(updateName);
+        assertThat(tagRepository.count()).isEqualTo(beforeUpdateCnt);
+
+    }
+
+
+
+
+
+
+}


### PR DESCRIPTION
**#54 테스트 코드 작성 - CategoryRepository, TagRepository, EduTagRepository 및 Entity 깃랩과 동기화**

Spring Data Jpa가 제공하는 기본적인 CRUD기능 테스트

- save

- count

- findById

- findAll

- update

- delete

> CategoryRepository, TagRepository, EduTagRepository 추가 
> User, Education, EduTag, Tag, Category 엔티티 클래스 수정