### PR TITLE
#145 Api 작성 - education

### DIFF
--- a/src/main/java/com/gabia/gyebalja/common/HashTagRegularExpression.java
+++ b/src/main/java/com/gabia/gyebalja/common/HashTagRegularExpression.java
@@ -1,0 +1,39 @@
+package com.gabia.gyebalja.common;
+
+import org.springframework.util.StringUtils;
+
+import java.util.ArrayList;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class HashTagRegularExpression {
+
+    public ArrayList<String> getExtractHashTag(String hashtag) {
+
+        ArrayList<String> resultHashtag = new ArrayList<>();
+
+        Pattern p = Pattern.compile("\\#([0-9a-zA-Z가-힣]*)");
+        Matcher m = p.matcher(hashtag);
+        String extractHashTag = null;
+
+        while(m.find()) {
+            extractHashTag = sepcialCharacter_replace(m.group());
+
+            if(extractHashTag != null) {
+                resultHashtag.add(extractHashTag);
+            }
+        }
+
+        return resultHashtag;
+    }
+    public String sepcialCharacter_replace(String str) {
+        str = StringUtils.replace(str, "-_+=!@#$%^&*()[]{}|\\;:'\"<>,.?/~`） ","");
+
+        if(str.length() < 2) {
+            return null;
+        }
+
+        return str;
+    }
+
+}

--- a/src/main/java/com/gabia/gyebalja/controller/EducationApiController.java
+++ b/src/main/java/com/gabia/gyebalja/controller/EducationApiController.java
@@ -1,11 +1,11 @@
 package com.gabia.gyebalja.controller;
 
 import com.gabia.gyebalja.common.CommonJsonFormat;
+import com.gabia.gyebalja.dto.education.EducationAllResponseDto;
+import com.gabia.gyebalja.dto.education.EducationDetailResponseDto;
 import com.gabia.gyebalja.dto.education.EducationRequestDto;
-import com.gabia.gyebalja.dto.education.EducationResponseDto;
 import com.gabia.gyebalja.service.EducationService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
@@ -16,6 +16,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RequiredArgsConstructor  //생성자 주입방식을 사용하기 위해 사용
 @RestController
@@ -35,7 +37,7 @@ public class EducationApiController {
     /** 조회 - education 한 건 (상세페이지) */
     @GetMapping("/api/v1/educations/{id}")
     public CommonJsonFormat getOneEducation(@PathVariable("id") Long id) {
-        EducationResponseDto educationResponseDto = educationService.getOneEducation(id);
+        EducationDetailResponseDto educationResponseDto = educationService.getOneEducation(id);
 
         return new CommonJsonFormat(200,"success",educationResponseDto);
     }
@@ -59,7 +61,7 @@ public class EducationApiController {
     /** 조회 - education 전체 (페이징) */
     @GetMapping("/api/v1/users/{id}/educations")
     public CommonJsonFormat getAllEducationByUserId(@PathVariable("id") Long id, @PageableDefault(size=10, sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
-        Page<EducationResponseDto> educationDtoPage = educationService.getAllEducationByUserId(id, pageable);
+        List<EducationAllResponseDto> educationDtoPage = educationService.getAllEducationByUserId(id, pageable);
 
         return new CommonJsonFormat(200, "success", educationDtoPage);
     }

--- a/src/main/java/com/gabia/gyebalja/controller/EducationApiController.java
+++ b/src/main/java/com/gabia/gyebalja/controller/EducationApiController.java
@@ -1,6 +1,7 @@
 package com.gabia.gyebalja.controller;
 
 import com.gabia.gyebalja.common.CommonJsonFormat;
+import com.gabia.gyebalja.common.StatusCode;
 import com.gabia.gyebalja.dto.education.EducationAllResponseDto;
 import com.gabia.gyebalja.dto.education.EducationDetailResponseDto;
 import com.gabia.gyebalja.dto.education.EducationRequestDto;
@@ -31,7 +32,7 @@ public class EducationApiController {
     public CommonJsonFormat postOneEducation(@RequestBody EducationRequestDto educationRequestDto) {
         Long eduId = educationService.postOneEducation(educationRequestDto);
 
-        return new CommonJsonFormat(200,"success",eduId);
+        return new CommonJsonFormat(StatusCode.OK.getCode(),StatusCode.OK.getMessage(),eduId);
     }
 
     /** 조회 - education 한 건 (상세페이지) */
@@ -39,7 +40,7 @@ public class EducationApiController {
     public CommonJsonFormat getOneEducation(@PathVariable("id") Long id) {
         EducationDetailResponseDto educationResponseDto = educationService.getOneEducation(id);
 
-        return new CommonJsonFormat(200,"success",educationResponseDto);
+        return new CommonJsonFormat(StatusCode.OK.getCode(),StatusCode.OK.getMessage(),educationResponseDto);
     }
 
     /** 수정 - education 한 건 (상세페이지) */
@@ -47,7 +48,7 @@ public class EducationApiController {
     public CommonJsonFormat putOneEducation(@PathVariable("id") Long id, @RequestBody EducationRequestDto educationRequestDto) {
         Long eduId = educationService.putOneEducation(id, educationRequestDto);
 
-        return new CommonJsonFormat(200,"success",eduId);
+        return new CommonJsonFormat(StatusCode.OK.getCode(),StatusCode.OK.getMessage(),eduId);
     }
 
     /** 삭제 - education 한 건 (상세페이지) */
@@ -55,7 +56,7 @@ public class EducationApiController {
     public CommonJsonFormat deleteOneEducation(@PathVariable("id") Long id) {
         Long eduId = educationService.deleteOneEducation(id);
 
-        return new CommonJsonFormat(200, "success", eduId);
+        return new CommonJsonFormat(StatusCode.OK.getCode(),StatusCode.OK.getMessage(), eduId);
     }
 
     /** 조회 - education 전체 (페이징) */
@@ -63,7 +64,7 @@ public class EducationApiController {
     public CommonJsonFormat getAllEducationByUserId(@PathVariable("id") Long id, @PageableDefault(size=10, sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
         List<EducationAllResponseDto> educationDtoPage = educationService.getAllEducationByUserId(id, pageable);
 
-        return new CommonJsonFormat(200, "success", educationDtoPage);
+        return new CommonJsonFormat(StatusCode.OK.getCode(),StatusCode.OK.getMessage(), educationDtoPage);
     }
 }
 

--- a/src/main/java/com/gabia/gyebalja/domain/Education.java
+++ b/src/main/java/com/gabia/gyebalja/domain/Education.java
@@ -83,7 +83,7 @@ public class Education extends BaseTime {
     }
 
     //교육내용 변경 메서드
-    public void changeEducation(String title, String content, LocalDate startDate, LocalDate endDate, int totalHours, EducationType type, String place ) {
+    public void changeEducation(String title, String content, LocalDate startDate, LocalDate endDate, int totalHours, EducationType type, String place ,Category category) {
         this.title = title;
         this.content = content;
         this.startDate = startDate;
@@ -91,6 +91,7 @@ public class Education extends BaseTime {
         this.totalHours = totalHours;
         this.type = type;
         this.place = place;
+        this.category = category;
     }
 
 }

--- a/src/main/java/com/gabia/gyebalja/domain/Education.java
+++ b/src/main/java/com/gabia/gyebalja/domain/Education.java
@@ -4,17 +4,11 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
-import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
+
+import javax.persistence.*;
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED) //프록시가 이생성자를 사용함 다른생성자를 사용하려면 기본생성자가 필요한데 Protected로 기본생성자를 만들어줌.
@@ -62,8 +56,12 @@ public class Education extends BaseTime {
     @JoinColumn(name = "category_id")
     private Category category;
 
+    //EduTag와 연관관계 (양방향 설정)
+    @OneToMany(mappedBy = "education", cascade = CascadeType.ALL)
+    private List<EduTag> eduTags = new ArrayList<>();
+
     @Builder
-    public Education(String title, String content, LocalDate startDate, LocalDate endDate, int totalHours, EducationType type, String place, User user, Category category ) {
+    public Education(String title, String content, LocalDate startDate, LocalDate endDate, int totalHours, EducationType type, String place, User user, Category category) {
         this.title = title;
         this.content = content;
         this.startDate = startDate;

--- a/src/main/java/com/gabia/gyebalja/dto/education/EducationAllResponseDto.java
+++ b/src/main/java/com/gabia/gyebalja/dto/education/EducationAllResponseDto.java
@@ -1,16 +1,15 @@
 package com.gabia.gyebalja.dto.education;
 
 import com.gabia.gyebalja.domain.EducationType;
+import com.gabia.gyebalja.dto.category.CategoryResponseDto;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-
 import java.time.LocalDate;
 
 @NoArgsConstructor
 @Data
-public class EducationResponseDto {
-
+public class EducationAllResponseDto {
     private Long id;
     private String title;
     private String content;
@@ -19,9 +18,10 @@ public class EducationResponseDto {
     private int totalHours;
     private EducationType type;
     private String place;
+    private CategoryResponseDto category;  // Category category는 Entity를 그대로 노출 하는 것이므로
 
     @Builder
-    public EducationResponseDto(Long id, String title, String content, LocalDate startDate, LocalDate endDate, int totalHours, EducationType type, String place ) {
+    public EducationAllResponseDto(Long id, String title, String content, LocalDate startDate, LocalDate endDate, int totalHours, EducationType type, String place, CategoryResponseDto category) {
         this.id = id;
         this.title = title;
         this.content = content;
@@ -30,5 +30,6 @@ public class EducationResponseDto {
         this.totalHours = totalHours;
         this.type = type;
         this.place = place;
+        this.category = category;
     }
 }

--- a/src/main/java/com/gabia/gyebalja/dto/education/EducationAllResponseDto.java
+++ b/src/main/java/com/gabia/gyebalja/dto/education/EducationAllResponseDto.java
@@ -12,7 +12,6 @@ import java.time.LocalDate;
 public class EducationAllResponseDto {
     private Long id;
     private String title;
-    private String content;
     private LocalDate startDate;
     private LocalDate endDate;
     private int totalHours;
@@ -21,10 +20,9 @@ public class EducationAllResponseDto {
     private CategoryResponseDto category;  // Category category는 Entity를 그대로 노출 하는 것이므로
 
     @Builder
-    public EducationAllResponseDto(Long id, String title, String content, LocalDate startDate, LocalDate endDate, int totalHours, EducationType type, String place, CategoryResponseDto category) {
+    public EducationAllResponseDto(Long id, String title, LocalDate startDate, LocalDate endDate, int totalHours, EducationType type, String place, CategoryResponseDto category) {
         this.id = id;
         this.title = title;
-        this.content = content;
         this.startDate = startDate;
         this.endDate = endDate;
         this.totalHours = totalHours;

--- a/src/main/java/com/gabia/gyebalja/dto/education/EducationDetailResponseDto.java
+++ b/src/main/java/com/gabia/gyebalja/dto/education/EducationDetailResponseDto.java
@@ -1,0 +1,41 @@
+package com.gabia.gyebalja.dto.education;
+
+import com.gabia.gyebalja.domain.EducationType;
+import com.gabia.gyebalja.dto.category.CategoryResponseDto;
+import com.gabia.gyebalja.dto.edutag.EduTagResponseDto;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import java.time.LocalDate;
+import java.util.List;
+
+@NoArgsConstructor
+@Data
+public class EducationDetailResponseDto {
+
+    private Long id;
+    private String title;
+    private String content;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private int totalHours;
+    private EducationType type;
+    private String place;
+    private CategoryResponseDto category;  // Category category는 Entity를 그대로 노출 하는 것이므로
+    private List<EduTagResponseDto> eduTags; // Dto 내부속에서도 Entity와의 관계를 다 끊어주기 위해 Dto로 받음
+
+    @Builder
+    public EducationDetailResponseDto(Long id, String title, String content, LocalDate startDate, LocalDate endDate, int totalHours, EducationType type, String place, CategoryResponseDto category, List<EduTagResponseDto> eduTag) {
+        this.id = id;
+        this.title = title;
+        this.content = content;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.totalHours = totalHours;
+        this.type = type;
+        this.place = place;
+        this.category = category;
+        this.eduTags = eduTag;
+    }
+
+}

--- a/src/main/java/com/gabia/gyebalja/dto/education/EducationRequestDto.java
+++ b/src/main/java/com/gabia/gyebalja/dto/education/EducationRequestDto.java
@@ -1,14 +1,10 @@
 package com.gabia.gyebalja.dto.education;
 
-import com.gabia.gyebalja.domain.Education;
 import com.gabia.gyebalja.domain.EducationType;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-
-import javax.validation.constraints.Min;
 import java.time.LocalDate;
-import java.util.ArrayList;
 
 @NoArgsConstructor
 @Data
@@ -23,11 +19,11 @@ public class EducationRequestDto {
     private String place;
     private Long userId;
     private Long categoryId;
-    private ArrayList<Long> tagId = new ArrayList<>();
+    private String hashTag;
 
 
     @Builder
-    public EducationRequestDto( String title, String content, LocalDate startDate, LocalDate endDate, int totalHours, EducationType type, String place, Long userId, Long categoryId, ArrayList<Long> tagId ) {
+    public EducationRequestDto( String title, String content, LocalDate startDate, LocalDate endDate, int totalHours, EducationType type, String place, Long userId, Long categoryId, String hashTag ) {
         this.title = title;
         this.content = content;
         this.startDate = startDate;
@@ -37,7 +33,7 @@ public class EducationRequestDto {
         this.place = place;
         this.userId = userId;
         this.categoryId = categoryId;
-        this.tagId = tagId;
+        this.hashTag = hashTag;
     }
 
 }

--- a/src/main/java/com/gabia/gyebalja/dto/edutag/EduTagRequestDto.java
+++ b/src/main/java/com/gabia/gyebalja/dto/edutag/EduTagRequestDto.java
@@ -1,0 +1,4 @@
+package com.gabia.gyebalja.dto.edutag;
+
+public class EduTagRequestDto {
+}

--- a/src/main/java/com/gabia/gyebalja/dto/edutag/EduTagResponseDto.java
+++ b/src/main/java/com/gabia/gyebalja/dto/edutag/EduTagResponseDto.java
@@ -1,0 +1,21 @@
+package com.gabia.gyebalja.dto.edutag;
+
+import com.gabia.gyebalja.domain.EduTag;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Data
+public class EduTagResponseDto {
+    //클라이언트 입장에서는 관계 테이블인 EduTag의 정보보다는 Tag의 정보가 필요함으로
+    //API 상에서도 Depth를 줄일 수있고 필요한 tagid와 tagName만 반환하도록 EduTagResponseDto 작성
+    private Long tagId;
+    private String tagName;
+
+    @Builder
+    public EduTagResponseDto(EduTag eduTag) {
+        this.tagId = eduTag.getTag().getId();
+        this.tagName = eduTag.getTag().getName();
+    }
+}

--- a/src/main/java/com/gabia/gyebalja/exception/NotExistEducationException.java
+++ b/src/main/java/com/gabia/gyebalja/exception/NotExistEducationException.java
@@ -1,0 +1,11 @@
+package com.gabia.gyebalja.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.FORBIDDEN)
+public class NotExistEducationException extends RuntimeException {
+    public NotExistEducationException(String msg) {
+        super(msg);
+    }
+}

--- a/src/main/java/com/gabia/gyebalja/repository/EduTagRepository.java
+++ b/src/main/java/com/gabia/gyebalja/repository/EduTagRepository.java
@@ -2,7 +2,14 @@ package com.gabia.gyebalja.repository;
 
 import com.gabia.gyebalja.domain.EduTag;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface EduTagRepository extends JpaRepository<EduTag, Long> {
-
+    @Modifying
+    @Transactional
+    @Query("delete from EduTag et where et.education.id = :eduId")
+    void deleteByEduId(@Param("eduId") Long eduId);
 }

--- a/src/main/java/com/gabia/gyebalja/repository/EducationRepository.java
+++ b/src/main/java/com/gabia/gyebalja/repository/EducationRepository.java
@@ -4,9 +4,21 @@ import com.gabia.gyebalja.domain.Education;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface EducationRepository extends JpaRepository<Education,Long> {
-    Page<Education> findByUserId(Long id, Pageable pageble);
+    //사용자의 교육목록을 가져오기 위한 메서드
+    //Page<Education> findByUserId(Long id, Pageable pageble);
+
+    //교육 상세조회 (N+1 문제 해결을 위한 fetch 조인 (Category는 필수 입력항목이라 inner join , Tag는 필수가 아니기때문에 left join))
+    @Query("select distinct e from Education e join fetch e.category c left join fetch e.eduTags et left join fetch et.tag t where e.id = :educationId")
+    Optional<Education> findEducationDetail(@Param("educationId") Long educationId);
+
+    //사용자의 교육목록을 가져오기 위한 메서드
+    @Query("select e from Education e join fetch e.category c where e.user.id = :userId")
+    List<Education> findEducationByUserId(@Param("userId") Long userId, Pageable pageable);
 }

--- a/src/main/java/com/gabia/gyebalja/repository/EducationRepository.java
+++ b/src/main/java/com/gabia/gyebalja/repository/EducationRepository.java
@@ -1,7 +1,6 @@
 package com.gabia.gyebalja.repository;
 
 import com.gabia.gyebalja.domain.Education;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;

--- a/src/main/java/com/gabia/gyebalja/repository/TagRepository.java
+++ b/src/main/java/com/gabia/gyebalja/repository/TagRepository.java
@@ -3,5 +3,10 @@ package com.gabia.gyebalja.repository;
 import com.gabia.gyebalja.domain.Tag;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface TagRepository extends JpaRepository<Tag,Long> {
+
+    //태그 이름으로 조회
+    Optional<Tag> findHashTagByName(String tagName);
 }

--- a/src/main/java/com/gabia/gyebalja/service/EducationService.java
+++ b/src/main/java/com/gabia/gyebalja/service/EducationService.java
@@ -3,8 +3,11 @@ package com.gabia.gyebalja.service;
 import com.gabia.gyebalja.domain.Category;
 import com.gabia.gyebalja.domain.Education;
 import com.gabia.gyebalja.domain.User;
+import com.gabia.gyebalja.dto.category.CategoryResponseDto;
+import com.gabia.gyebalja.dto.education.EducationAllResponseDto;
+import com.gabia.gyebalja.dto.education.EducationDetailResponseDto;
 import com.gabia.gyebalja.dto.education.EducationRequestDto;
-import com.gabia.gyebalja.dto.education.EducationResponseDto;
+import com.gabia.gyebalja.dto.edutag.EduTagResponseDto;
 import com.gabia.gyebalja.exception.NotExistCategoryException;
 import com.gabia.gyebalja.exception.NotExistUserException;
 import com.gabia.gyebalja.repository.CategoryRepository;
@@ -12,13 +15,14 @@ import com.gabia.gyebalja.repository.EduTagRepository;
 import com.gabia.gyebalja.repository.EducationRepository;
 import com.gabia.gyebalja.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static java.util.stream.Collectors.toList;
 
 @RequiredArgsConstructor //final의 필드만 가지고 생성자를 만들어줌
 @Transactional(readOnly = true)
@@ -62,18 +66,33 @@ public class EducationService {
     }
 
     /** 조회 - education 한 건 (상세페이지) */
-    public EducationResponseDto getOneEducation(Long id) {
-        Education education = educationRepository.findById(id).orElseThrow(() -> new IllegalArgumentException("해당 데이터가 없습니다."));
+    public EducationDetailResponseDto getOneEducation(Long id) {
+        //N+1 문제 해결을 위한 fetch join 사용 (성능 최적화)
+        Optional<Education> education = educationRepository.findEducationDetail(id);
 
-        return EducationResponseDto.builder()
-                .id(education.getId())
-                .title(education.getTitle())
-                .content(education.getContent())
-                .startDate(education.getStartDate())
-                .endDate(education.getEndDate())
-                .totalHours(education.getTotalHours())
-                .type(education.getType())
-                .place(education.getPlace())
+        if(!education.isPresent())
+            throw new NotExistCategoryException("존재하지 않는 교육입니다.");
+
+        CategoryResponseDto categoryResponseDto = CategoryResponseDto.builder()
+                                                                        .id(education.get().getCategory().getId())
+                                                                        .name(education.get().getCategory().getName())
+                                                                        .build();
+
+
+        List<EduTagResponseDto> tagList = education.get().getEduTags().stream().map(EduTagResponseDto::new)
+                                                                        .collect(toList());
+
+        return EducationDetailResponseDto.builder()
+                .id(education.get().getId())
+                .title(education.get().getTitle())
+                .content(education.get().getContent())
+                .startDate(education.get().getStartDate())
+                .endDate(education.get().getEndDate())
+                .totalHours(education.get().getTotalHours())
+                .type(education.get().getType())
+                .place(education.get().getPlace())
+                .category(categoryResponseDto)
+                .eduTag(tagList)
                 .build();
     }
 
@@ -96,19 +115,28 @@ public class EducationService {
     }
 
     /** 조회 - education 전체 (페이징) */
-    public Page<EducationResponseDto> getAllEducationByUserId(Long id, Pageable pageable) {
-        Page<Education> educationPage = educationRepository.findByUserId(id, pageable);
-        Page<EducationResponseDto> educationDtoPage = educationPage.map(education -> new EducationResponseDto().builder()
-                                                                                                                .id(education.getId())
-                                                                                                                .title(education.getTitle())
-                                                                                                                .content(education.getContent())
-                                                                                                                .startDate(education.getStartDate())
-                                                                                                                .endDate(education.getEndDate())
-                                                                                                                .totalHours(education.getTotalHours())
-                                                                                                                .type(education.getType())
-                                                                                                                .place(education.getPlace())
-                                                                                                                .build());
+    public List<EducationAllResponseDto> getAllEducationByUserId(Long id, Pageable pageable) {
+
+        Optional<User> findUser = userRepository.findById(id);
+
+        if(!findUser.isPresent())
+            throw new NotExistUserException("존재하지 않는 회원입니다.");
+
+        List<Education> educationPage = educationRepository.findEducationByUserId(id, pageable);
+
+        List<EducationAllResponseDto> educationDtoPage = educationPage.stream().map(e -> new EducationAllResponseDto().builder()
+                                                                                                            .id(e.getId())
+                                                                                                            .title(e.getTitle())
+                                                                                                            .content(e.getContent())
+                                                                                                            .startDate(e.getStartDate())
+                                                                                                            .endDate(e.getEndDate())
+                                                                                                            .totalHours(e.getTotalHours())
+                                                                                                            .type(e.getType())
+                                                                                                            .place(e.getPlace())
+                                                                                                            .category(CategoryResponseDto.builder().id(e.getCategory().getId()).name(e.getCategory().getName()).build())
+                                                                                                            .build()).collect(Collectors.toList());
         return educationDtoPage;
+
     }
 
 }

--- a/src/test/java/com/gabia/gyebalja/education/EducationControllerTest.java
+++ b/src/test/java/com/gabia/gyebalja/education/EducationControllerTest.java
@@ -59,15 +59,15 @@ public class EducationControllerTest {
     @PersistenceContext
     EntityManager em;
 
-//    @AfterEach
-//    public void cleanUp() {
-//        System.out.println("============================ cleanUp()");
-//        //TestRestTemplate은 Transaction을 못 걸어주므로 테스트 종료 후 수동으로 디비 초기화
-//        this.educationRepository.deleteAll();
-//        this.userRepository.deleteAll();
-//        this.categoryRepository.deleteAll();
-//        this.departmentRepository.deleteAll();
-//    }
+    @AfterEach
+    public void cleanUp() {
+        System.out.println("============================ cleanUp()");
+        //TestRestTemplate은 Transaction을 못 걸어주므로 테스트 종료 후 수동으로 디비 초기화
+        this.educationRepository.deleteAll();
+        this.userRepository.deleteAll();
+        this.categoryRepository.deleteAll();
+        this.departmentRepository.deleteAll();
+    }
 
     /**
      * 등록 - education 한 건 (자기교육 등록)

--- a/src/test/java/com/gabia/gyebalja/education/EducationControllerTest.java
+++ b/src/test/java/com/gabia/gyebalja/education/EducationControllerTest.java
@@ -7,8 +7,8 @@ import com.gabia.gyebalja.domain.Education;
 import com.gabia.gyebalja.domain.EducationType;
 import com.gabia.gyebalja.domain.GenderType;
 import com.gabia.gyebalja.domain.User;
+import com.gabia.gyebalja.dto.education.EducationDetailResponseDto;
 import com.gabia.gyebalja.dto.education.EducationRequestDto;
-import com.gabia.gyebalja.dto.education.EducationResponseDto;
 import com.gabia.gyebalja.repository.CategoryRepository;
 import com.gabia.gyebalja.repository.DepartmentRepository;
 import com.gabia.gyebalja.repository.EducationRepository;
@@ -26,7 +26,6 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import java.time.LocalDate;
@@ -127,7 +126,7 @@ public class EducationControllerTest {
 
         //when
         ResponseEntity<CommonJsonFormat> responseEntity = restTemplate.postForEntity(url, educationRequestDto, CommonJsonFormat.class);
-        EducationResponseDto findEducation = educationService.getOneEducation(Long.parseLong(responseEntity.getBody().getResponse().toString()));
+        EducationDetailResponseDto findEducation = educationService.getOneEducation(Long.parseLong(responseEntity.getBody().getResponse().toString()));
         //then
         assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(responseEntity.getBody().getCode()).isEqualTo(200);
@@ -408,8 +407,7 @@ public class EducationControllerTest {
         // when
         CommonJsonFormat responseEntity = restTemplate.getForObject(url, CommonJsonFormat.class);
         // then
-        LinkedHashMap response = (LinkedHashMap) responseEntity.getResponse();
-        ArrayList result = (ArrayList) response.get("content");
+        ArrayList result = (ArrayList) responseEntity.getResponse();
         assertThat(result.size()).isEqualTo(10); //추후 검증로직 추가 예정
     }
 

--- a/src/test/java/com/gabia/gyebalja/education/EducationControllerTest.java
+++ b/src/test/java/com/gabia/gyebalja/education/EducationControllerTest.java
@@ -59,15 +59,15 @@ public class EducationControllerTest {
     @PersistenceContext
     EntityManager em;
 
-    @AfterEach
-    public void cleanUp() {
-        System.out.println("============================ cleanUp()");
-        //TestRestTemplate은 Transaction을 못 걸어주므로 테스트 종료 후 수동으로 디비 초기화
-        this.educationRepository.deleteAll();
-        this.userRepository.deleteAll();
-        this.categoryRepository.deleteAll();
-        this.departmentRepository.deleteAll();
-    }
+//    @AfterEach
+//    public void cleanUp() {
+//        System.out.println("============================ cleanUp()");
+//        //TestRestTemplate은 Transaction을 못 걸어주므로 테스트 종료 후 수동으로 디비 초기화
+//        this.educationRepository.deleteAll();
+//        this.userRepository.deleteAll();
+//        this.categoryRepository.deleteAll();
+//        this.departmentRepository.deleteAll();
+//    }
 
     /**
      * 등록 - education 한 건 (자기교육 등록)
@@ -113,16 +113,17 @@ public class EducationControllerTest {
         String place = "가비아 3층";
 
         EducationRequestDto educationRequestDto = EducationRequestDto.builder()
-                .title(title)
-                .content(content)
-                .startDate(startDate)
-                .endDate(endDate)
-                .totalHours(totalHours)
-                .type(type)
-                .place(place)
-                .userId(user.getId())
-                .categoryId(category.getId())
-                .build();
+                                                    .title(title)
+                                                    .content(content)
+                                                    .startDate(startDate)
+                                                    .endDate(endDate)
+                                                    .totalHours(totalHours)
+                                                    .type(type)
+                                                    .place(place)
+                                                    .userId(user.getId())
+                                                    .categoryId(category.getId())
+                                                    .hashTag("#")
+                                                    .build();
 
         //when
         ResponseEntity<CommonJsonFormat> responseEntity = restTemplate.postForEntity(url, educationRequestDto, CommonJsonFormat.class);

--- a/src/test/java/com/gabia/gyebalja/education/EducationServiceTest.java
+++ b/src/test/java/com/gabia/gyebalja/education/EducationServiceTest.java
@@ -26,6 +26,7 @@ import org.springframework.transaction.annotation.Transactional;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -81,7 +82,7 @@ public class EducationServiceTest {
         userRepository.save(user);
 
         EducationRequestDto educationRequestDto = EducationRequestDto.builder()
-                .title("제목테스트")
+                .title("test")
                 .content("내용테스트")
                 .startDate(LocalDate.now())
                 .endDate(LocalDate.now())
@@ -90,6 +91,7 @@ public class EducationServiceTest {
                 .place("가비아 4층")
                 .categoryId(category.getId())
                 .userId(user.getId())
+                .hashTag("#Spring #CSS #HTML")
                 .build();
         //when
         Long saveId = educationService.postOneEducation(educationRequestDto);
@@ -334,12 +336,6 @@ public class EducationServiceTest {
 
     @Test
     public void practice() throws Exception {
-        //given
-        String tag = "#Spring Jpa #HTML      #test";
-        //when
-
-        //then
-
     }
 
 }

--- a/src/test/java/com/gabia/gyebalja/education/EducationServiceTest.java
+++ b/src/test/java/com/gabia/gyebalja/education/EducationServiceTest.java
@@ -6,8 +6,9 @@ import com.gabia.gyebalja.domain.Education;
 import com.gabia.gyebalja.domain.EducationType;
 import com.gabia.gyebalja.domain.GenderType;
 import com.gabia.gyebalja.domain.User;
+import com.gabia.gyebalja.dto.education.EducationAllResponseDto;
+import com.gabia.gyebalja.dto.education.EducationDetailResponseDto;
 import com.gabia.gyebalja.dto.education.EducationRequestDto;
-import com.gabia.gyebalja.dto.education.EducationResponseDto;
 import com.gabia.gyebalja.repository.CategoryRepository;
 import com.gabia.gyebalja.repository.DepartmentRepository;
 import com.gabia.gyebalja.repository.EducationRepository;
@@ -18,7 +19,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -26,6 +26,7 @@ import org.springframework.transaction.annotation.Transactional;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -148,7 +149,7 @@ public class EducationServiceTest {
         educationRepository.save(education);
         em.clear();
         //when
-        EducationResponseDto findEducation = educationService.getOneEducation(education.getId());
+        EducationDetailResponseDto findEducation = educationService.getOneEducation(education.getId());
         //then
         assertThat(findEducation.getId()).isEqualTo(education.getId());
         assertThat(findEducation.getTitle()).isEqualTo(education.getTitle());
@@ -326,10 +327,19 @@ public class EducationServiceTest {
             educationService.postOneEducation(educationRequestDto);
         }
         //when
-        Page<EducationResponseDto> allEducationByUserId = educationService.getAllEducationByUserId(user.getId(), pageable);
+        List<EducationAllResponseDto> allEducationByUserId = educationService.getAllEducationByUserId(user.getId(), pageable);
         //then
-        assertThat(allEducationByUserId.getContent().size()).isEqualTo(10); //한 페이지당 데이터 10개
-        assertThat(allEducationByUserId.getTotalPages()).isEqualTo(3);  //30개를 넣었으니 3페이지
+        assertThat(allEducationByUserId.size()).isEqualTo(10); //한 페이지당 데이터 10개
+    }
+
+    @Test
+    public void practice() throws Exception {
+        //given
+        String tag = "#Spring Jpa #HTML      #test";
+        //when
+
+        //then
+
     }
 
 }


### PR DESCRIPTION
**#145 Api 작성 - education**

- 상세 조회 시 태그 정보, 카테고리 정보 같이 보여주기

- N+1 문제 해결 및 예외처리

- 상세조회와 전체조회 ResponseDto 분리

- Education과 EduTag 양방향 관계 설정

- 해시태그 추출 클래스 추가

- EducationApiController 리턴 값 상수 -> enum 클래스 사용으로 변경

- 등록 로직에 해시태그로직 추가

- 수정 로직에 해시태그 로직 추가

- 전체 조회 Dto에 content 필드 제외

- 로직에 필요한 쿼리메소드 작성

- 해시태그 선택방식이 아닌 입력 방식으로 변경함으로써 RequestDto 수정